### PR TITLE
Feature/command delete user

### DIFF
--- a/src/Command/CreateUserCommand.php
+++ b/src/Command/CreateUserCommand.php
@@ -63,7 +63,7 @@ class CreateUserCommand extends Command
         $usernameQuestion = new Question('Enter an unknown username : ', 'username');
         $usernameQuestion->setAutocompleterValues($this->usernamesList);
         $usernameQuestion->setValidator(function($answer){
-           if(in_array($answer, $this->usernamesList)){
+           if($this->usernamesList && in_array($answer, $this->usernamesList)){
                throw new \RuntimeException(
                    'New user need an unique username.'
                );
@@ -75,7 +75,7 @@ class CreateUserCommand extends Command
         $emailQuestion = new Question('Enter an unknown email : ', 'email@email.com');
         $emailQuestion->setAutocompleterValues($this->emailsList);
         $emailQuestion->setValidator(function($answer){
-           if(in_array($answer, $this->emailsList)){
+           if($this->emailsList && in_array($answer, $this->emailsList)){
                throw new \RuntimeException(
                    'New user need an unique email.'
                );

--- a/src/Command/DeleteUserCommand.php
+++ b/src/Command/DeleteUserCommand.php
@@ -31,6 +31,10 @@ class DeleteUserCommand extends Command
      */
     private $users;
 
+    /**
+     * DeleteUserCommand constructor.
+     * @param ObjectManager $objectManager
+     */
     public function __construct(ObjectManager $objectManager)
     {
         $this->objectManager = $objectManager;
@@ -40,6 +44,9 @@ class DeleteUserCommand extends Command
         parent::__construct();
     }
 
+    /**
+     * Configure (option, argument, etc.) of our command
+     */
     protected function configure()
     {
         $this
@@ -79,6 +86,12 @@ class DeleteUserCommand extends Command
         ;
     }
 
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return int|void|null
+     * @throws \Exception
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $daysOption = $input->getOption('day');

--- a/src/Command/DeleteUserCommand.php
+++ b/src/Command/DeleteUserCommand.php
@@ -45,9 +45,15 @@ class DeleteUserCommand extends Command
                 Specified X days with argument. 
                 Default 5 days.'
             )
-            ->setHelp('This command allow you to create an user.')
+            ->setHelp('This command allow you to delete users which were inactive since X days.')
             ->setDefinition(array(
-                new InputOption('day', '-d')
+                new InputOption(
+                    'day',
+                    '-d',
+                    InputOption::VALUE_OPTIONAL,
+                    'How many inactive days ? Default 60',
+                    60
+                )
             ))
         ;
     }
@@ -61,6 +67,16 @@ class DeleteUserCommand extends Command
             '==========================================',
             '',
         ]);
+
+        if(!is_numeric($input->getOption('day'))){
+            $output->writeln([
+                '<fg=black;bg=cyan>================================================',
+                '     --day option need to be numeric type !     ',
+                '================================================</>',
+                '',
+            ]);
+            die;
+        }
 
         $output->writeln("All inactive and unverified (since 60 days ago) users were deleted. \n");
     }

--- a/src/Command/DeleteUserCommand.php
+++ b/src/Command/DeleteUserCommand.php
@@ -105,7 +105,7 @@ class DeleteUserCommand extends Command
             );
         }
 
-        if(!is_null($forceOption)){
+        if($forceOption !== null){
             throw new \RuntimeException(
                 'You need use \'--force\' or \'-f\' to use this command with no value'
             );
@@ -122,7 +122,7 @@ class DeleteUserCommand extends Command
         foreach($this->users as $user){
             $interval = date_diff($user->getUpdatedAt(), $now);
             if($interval->days >= $daysOption){
-                if(($user->getStatus() === self::DEACTIVATES) || (is_null($allOption) && $user->getStatus() === self::UNVERIFIED)){
+                if(($user->getStatus() === self::DEACTIVATES) || ($allOption === null && $user->getStatus() === self::UNVERIFIED)){
                     $this->objectManager->remove($user);
                     $this->objectManager->flush();
                     $output->writeln("User <comment>".$user->getEmail()."</comment> has been removed \n");

--- a/src/Command/DeleteUserCommand.php
+++ b/src/Command/DeleteUserCommand.php
@@ -7,7 +7,9 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\BufferedOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
@@ -37,9 +39,16 @@ class DeleteUserCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('user:delete')
-            ->setDescription('Create an user.')
+            ->setName('user:delete:inactive')
+            ->setDescription(
+                'Delete all users which were inactive since X days. 
+                Specified X days with argument. 
+                Default 5 days.'
+            )
             ->setHelp('This command allow you to create an user.')
+            ->setDefinition(array(
+                new InputOption('day', '-d')
+            ))
         ;
     }
 

--- a/src/Command/DeleteUserCommand.php
+++ b/src/Command/DeleteUserCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\User;
+use Doctrine\Common\Persistence\ObjectManager;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+
+class DeleteUserCommand extends Command
+{
+    /**
+     * @var ObjectManager
+     */
+    private $objectManager;
+    /**
+     * @var array
+     */
+    private $users;
+
+    public function __construct(ObjectManager $objectManager)
+    {
+        $this->objectManager = $objectManager;
+
+        $this->users = $this->objectManager->getRepository(User::class)->findAll();
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('user:delete')
+            ->setDescription('Create an user.')
+            ->setHelp('This command allow you to create an user.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $helper = $this->getHelper('question');
+        $output->writeln([
+            '==========================================',
+            '     Delete inactive/unverified users     ',
+            '==========================================',
+            '',
+        ]);
+
+        $output->writeln("All inactive and unverified (since 60 days ago) users were deleted. \n");
+    }
+}


### PR DESCRIPTION
I add : 
* Hotfix for create user command. This command doesn't work if you have no users in your database => it's fixed
* Command delete users deactivated (and if you active option, users unverified).

TUTO : 
* `php bin/console user:delete:deactivates` => Doesn't work. This command need to be force
* `php bin/console user:delete:deactivates --force` =>Delete deactivated users since 60 days
* `php bin/console user:delete:deactivates --force --day 10 ` => Delete deactivated users since 10 days
* `php bin/console user:delete:deactivates --force  --all ` =>Delete deactivated/unverified users since 60 days
* `php bin/console user:delete:deactivates --force --day 10 --all ` => Delete deactivated/unverified users since 10 days

OPTIONS : 
* `--force` or `-f`
* `--day` or `-d`
* `--all` or `-a`
